### PR TITLE
Install in correct cmake module dir

### DIFF
--- a/distro.json
+++ b/distro.json
@@ -7,7 +7,7 @@
           "url": "https://nxxm.indigenious.io/distro/v0.0.12/cmake/cmake-3.18.4-Darwin-x86_64.zip",
           "sha1": "c7aeea101063fe54911519fae5427096ed557398",
           "root": "cmake-3.18.4-Darwin-x86_64/CMake.app/Contents",
-          "module_path": "cmake/share/cmake-3.17/Modules",
+          "module_path": "cmake/share/cmake-3.18/Modules",
           "path": ["bin"]
         }
       },
@@ -16,7 +16,7 @@
           "url": "https://nxxm.indigenious.io/distro/v0.0.12/cmake/cmake-3.18.4-Linux-x86_64.zip",
           "sha1": "7e4b5225c96db5a135c034b4220925c87b4f9a5f",
           "root": "cmake-3.18.4-Linux-x86_64",
-          "module_path": "cmake/share/cmake-3.17/Modules",
+          "module_path": "cmake/share/cmake-3.18/Modules",
           "path": ["bin"]
         }
       },
@@ -25,7 +25,7 @@
           "url": "https://nxxm.indigenious.io/distro/v0.0.12/cmake/cmake-3.18.4-win64-x64.zip",
           "sha1": "51e611bb39f8f4c49a160085048e0dd24ec22812",
           "root": "cmake-3.18.4-win64-x64",
-          "module_path": "cmake/share/cmake-3.17/Modules",
+          "module_path": "cmake/share/cmake-3.18/Modules",
           "path": ["bin"]
         }
       }


### PR DESCRIPTION
Leading to our cmake not being able to load HunterGate by himself (if hunter calls cmake on a dep that needs it). For instance Poco hunterized couldn't find HunterGate module as hunter doesn't forward the module path of the parent project.